### PR TITLE
Implement Delete Button for User-Owned Links (#38)

### DIFF
--- a/my-link-uploader/src/components/ConfirmationModal.tsx
+++ b/my-link-uploader/src/components/ConfirmationModal.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Trash2 } from 'lucide-react';
 
 interface ConfirmationModalProps {
   isOpen: boolean;
@@ -18,19 +19,22 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ isOpen, onClose, 
         onClick={onClose}
       />
       {/* Modal content */}
-      <div className="relative z-10 bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md mx-auto flex flex-col items-center">
-        <div className="mb-6 text-center">
-          <p className="text-lg text-gray-100 font-semibold">{message}</p>
+      <div className="relative z-10 bg-gray-900 rounded-xl shadow-2xl p-8 w-full max-w-md mx-auto flex flex-col items-center border border-gray-700">
+        <div className="flex flex-col items-center mb-6">
+          <div className="w-16 h-16 flex items-center justify-center rounded-full bg-gradient-to-br from-pink-600 to-red-500 mb-4">
+            <Trash2 size={36} className="text-white" />
+          </div>
+          <p className="text-lg text-gray-100 font-semibold text-center">{message}</p>
         </div>
-        <div className="flex w-full justify-end gap-3 mt-4">
+        <div className="flex w-full justify-center gap-4 mt-4">
           <button
-            className="px-4 py-2 rounded bg-gray-600 text-gray-200 hover:bg-gray-500 transition"
+            className="px-5 py-2 rounded-lg bg-gray-700 text-gray-200 hover:bg-gray-600 transition font-medium"
             onClick={onClose}
           >
             Cancel
           </button>
           <button
-            className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 transition font-semibold"
+            className="px-5 py-2 rounded-lg bg-gradient-to-r from-pink-600 to-red-500 text-white hover:from-pink-700 hover:to-red-600 transition font-semibold shadow"
             onClick={onConfirm}
           >
             Yes, Delete

--- a/my-link-uploader/src/components/ConfirmationModal.tsx
+++ b/my-link-uploader/src/components/ConfirmationModal.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  message: string;
+}
+
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ isOpen, onClose, onConfirm, message }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Overlay */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-60 transition-opacity"
+        onClick={onClose}
+      />
+      {/* Modal content */}
+      <div className="relative z-10 bg-gray-800 rounded-lg shadow-lg p-8 w-full max-w-md mx-auto flex flex-col items-center">
+        <div className="mb-6 text-center">
+          <p className="text-lg text-gray-100 font-semibold">{message}</p>
+        </div>
+        <div className="flex w-full justify-end gap-3 mt-4">
+          <button
+            className="px-4 py-2 rounded bg-gray-600 text-gray-200 hover:bg-gray-500 transition"
+            onClick={onClose}
+          >
+            Cancel
+          </button>
+          <button
+            className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 transition font-semibold"
+            onClick={onConfirm}
+          >
+            Yes, Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmationModal; 

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -47,8 +47,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
 
   const handleVisit = (e: React.MouseEvent) => {
     e.stopPropagation();
-    console.log(`Visiting link: ${link.url}`);
-    // window.open(link.url, '_blank');
+    window.open(link.url, '_blank', 'noopener,noreferrer');
   };
 
   const formatDate = (dateString: string) => {
@@ -85,6 +84,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
           <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
             <span>{formatDate(link.created_at)}</span>
+            <span>{link.click_count} clicks</span>
           </div>
           <div className="mt-auto flex flex-col gap-2">
             <button
@@ -118,6 +118,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
           <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
             <span>{formatDate(link.created_at)}</span>
+            <span>{link.click_count} clicks</span>
           </div>
           <button
             className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
@@ -167,6 +168,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
         <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
         <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
           <span>{formatDate(link.created_at)}</span>
+          <span>{link.click_count} clicks</span>
         </div>
         <button
           className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { LinkIcon } from 'lucide-react';
+import { LinkIcon, ExternalLink } from 'lucide-react';
 import { formatInTimeZone } from 'date-fns-tz';
 
 interface LinkPreview {
@@ -88,10 +88,11 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           </div>
           <div className="mt-auto flex flex-col gap-2">
             <button
-              className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+              className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
               onClick={handleVisit}
             >
-              Visit Link
+              <ExternalLink size={20} />
+              <span>Visit Link</span>
             </button>
             <button
               className="w-full px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition text-sm"
@@ -119,10 +120,11 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
             <span>{formatDate(link.created_at)}</span>
           </div>
           <button
-            className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+            className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
             onClick={handleVisit}
           >
-            Visit Link
+            <ExternalLink size={20} />
+            <span>Visit Link</span>
           </button>
           <button
             className="w-full mt-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition text-sm"
@@ -167,10 +169,11 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           <span>{formatDate(link.created_at)}</span>
         </div>
         <button
-          className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+          className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
           onClick={handleVisit}
         >
-          Visit Link
+          <ExternalLink size={20} />
+          <span>Visit Link</span>
         </button>
       </div>
     </div>

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { LinkIcon, ExternalLink, User as UserIcon, Calendar, Clock } from 'lucide-react';
 import { formatInTimeZone } from 'date-fns-tz';
 import ConfirmationModal from './ConfirmationModal';
+import SuccessModal from './SuccessModal';
 
 interface LinkPreview {
   title?: string;
@@ -37,6 +38,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   const [imageError, setImageError] = useState(false);
   const [faviconError, setFaviconError] = useState(false);
   const [showModal, setShowModal] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
 
   const isOwner = currentUser && link.user_id === currentUser.id;
   const hasImage = !!link.preview?.image && !imageError;
@@ -49,10 +51,16 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   const handleConfirmDelete = () => {
     if (onDelete) onDelete(link.id);
     setShowModal(false);
+    setShowSuccess(true);
+    setTimeout(() => setShowSuccess(false), 2000);
   };
 
   const handleCloseModal = () => {
     setShowModal(false);
+  };
+
+  const handleCloseSuccess = () => {
+    setShowSuccess(false);
   };
 
   const handleVisit = (e: React.MouseEvent) => {
@@ -138,6 +146,11 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
               onConfirm={handleConfirmDelete}
               message="Are you sure you want to delete this link?"
             />
+            <SuccessModal
+              isOpen={showSuccess}
+              onClose={handleCloseSuccess}
+              message="Link deleted successfully!"
+            />
           </div>
         </div>
       </div>
@@ -189,6 +202,11 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
             onClose={handleCloseModal}
             onConfirm={handleConfirmDelete}
             message="Are you sure you want to delete this link?"
+          />
+          <SuccessModal
+            isOpen={showSuccess}
+            onClose={handleCloseSuccess}
+            message="Link deleted successfully!"
           />
         </div>
       </div>

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { LinkIcon, ExternalLink } from 'lucide-react';
+import { LinkIcon, ExternalLink, User as UserIcon, Calendar, Clock } from 'lucide-react';
 import { formatInTimeZone } from 'date-fns-tz';
 
 interface LinkPreview {
@@ -53,9 +53,18 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   const formatDate = (dateString: string) => {
     try {
       const date = new Date(dateString);
-      return formatInTimeZone(date, 'Africa/Douala', 'MMM d, yyyy HH:mm');
+      return formatInTimeZone(date, 'Africa/Douala', 'MMM d, yyyy');
     } catch (error) {
       return 'Invalid date';
+    }
+  };
+
+  const formatTime = (dateString: string) => {
+    try {
+      const date = new Date(dateString);
+      return formatInTimeZone(date, 'Africa/Douala', 'HH:mm');
+    } catch (error) {
+      return 'Invalid time';
     }
   };
 
@@ -82,9 +91,22 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
         <div className="p-4 flex-1 flex flex-col">
           <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
-          <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
-            <span>{formatDate(link.created_at)}</span>
-            <span>{link.click_count} clicks</span>
+          <div className="flex items-center gap-4 mb-2 text-sm text-gray-400">
+            <div className="flex items-center gap-1">
+              <UserIcon size={16} />
+              <span>{link.user?.username || 'Unknown user'}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Calendar size={16} />
+              <span>{formatDate(link.created_at)}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Clock size={16} />
+              <span>{formatTime(link.created_at)}</span>
+            </div>
+          </div>
+          <div className="mb-4 text-sm text-gray-400">
+            {link.click_count} clicks
           </div>
           <div className="mt-auto flex flex-col gap-2">
             <button
@@ -116,9 +138,22 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           </div>
           <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
-          <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
-            <span>{formatDate(link.created_at)}</span>
-            <span>{link.click_count} clicks</span>
+          <div className="flex items-center gap-4 mb-2 text-sm text-gray-400">
+            <div className="flex items-center gap-1">
+              <UserIcon size={16} />
+              <span>{link.user?.username || 'Unknown user'}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Calendar size={16} />
+              <span>{formatDate(link.created_at)}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Clock size={16} />
+              <span>{formatTime(link.created_at)}</span>
+            </div>
+          </div>
+          <div className="mb-4 text-sm text-gray-400">
+            {link.click_count} clicks
           </div>
           <button
             className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
@@ -166,9 +201,22 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
       <div className="p-4 flex-1 flex flex-col">
         <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
         <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
-        <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
-          <span>{formatDate(link.created_at)}</span>
-          <span>{link.click_count} clicks</span>
+        <div className="flex items-center gap-4 mb-2 text-sm text-gray-400">
+          <div className="flex items-center gap-1">
+            <UserIcon size={16} />
+            <span>{link.user?.username || 'Unknown user'}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Calendar size={16} />
+            <span>{formatDate(link.created_at)}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock size={16} />
+            <span>{formatTime(link.created_at)}</span>
+          </div>
+        </div>
+        <div className="mb-4 text-sm text-gray-400">
+          {link.click_count} clicks
         </div>
         <button
           className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { LinkIcon } from 'lucide-react';
-import './LinkCard.css';
 import { formatInTimeZone } from 'date-fns-tz';
 
 interface LinkPreview {
@@ -18,20 +16,39 @@ interface Link {
   description: string;
   click_count: number;
   created_at: string;
+  user_id: string;
   preview?: LinkPreview;
+  user?: { username: string };
+}
+
+interface User {
+  id: string;
+  username: string;
 }
 
 interface LinkCardProps {
   link: Link;
+  currentUser: User | null;
   onDelete?: (id: string) => void;
 }
 
-const LinkCard: React.FC<LinkCardProps> = ({ link }) => {
+const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   const [imageError, setImageError] = useState(false);
   const [faviconError, setFaviconError] = useState(false);
 
-  const handleClick = () => {
-    window.open(link.url, '_blank');
+  const isOwner = currentUser && link.user_id === currentUser.id;
+  const hasImage = !!link.preview?.image && !imageError;
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log(`Deleting link: ${link.id}`);
+    if (onDelete) onDelete(link.id);
+  };
+
+  const handleVisit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    console.log(`Visiting link: ${link.url}`);
+    // window.open(link.url, '_blank');
   };
 
   const formatDate = (dateString: string) => {
@@ -39,54 +56,125 @@ const LinkCard: React.FC<LinkCardProps> = ({ link }) => {
       const date = new Date(dateString);
       return formatInTimeZone(date, 'Africa/Douala', 'MMM d, yyyy HH:mm');
     } catch (error) {
-      console.error('Error formatting date:', error);
       return 'Invalid date';
     }
   };
 
-  const DefaultPreview = () => (
-    <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500">
-      <LinkIcon size={48} className="text-white" />
-    </div>
-  );
-
-  return (
-    <div 
-      className="link-card bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden hover:shadow-xl cursor-pointer"
-      onClick={handleClick}
-    >
-      <div className="link-card-image aspect-video">
-        {link.preview?.image && !imageError ? (
+  // Layout for owned links with images
+  if (isOwner && hasImage) {
+    return (
+      <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col">
+        <div className="relative aspect-video">
           <img
-            src={link.preview.image}
+            src={link.preview!.image}
+            alt={link.title}
+            className="w-full h-full object-cover"
+            onError={() => setImageError(true)}
+          />
+          {link.preview?.favicon && !faviconError && (
+            <img
+              src={link.preview.favicon}
+              alt="favicon"
+              className="absolute top-2 left-2 w-6 h-6 rounded-full bg-white"
+              onError={() => setFaviconError(true)}
+            />
+          )}
+        </div>
+        <div className="p-4 flex-1 flex flex-col">
+          <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
+          <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
+          <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
+            <span>{formatDate(link.created_at)}</span>
+            <span>{link.click_count} clicks</span>
+          </div>
+          <div className="mt-auto flex flex-col gap-2">
+            <button
+              className="ml-auto px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition"
+              onClick={handleDelete}
+            >
+              Delete
+            </button>
+            <button
+              className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+              onClick={handleVisit}
+            >
+              Visit Link
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Layout for owned links without images
+  if (isOwner && !hasImage) {
+    return (
+      <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col relative">
+        <button
+          className="absolute top-2 right-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition z-10"
+          onClick={handleDelete}
+        >
+          Delete
+        </button>
+        <div className="flex-1 flex flex-col p-4">
+          <div className="w-full h-32 flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500 rounded mb-4">
+            <LinkIcon size={48} className="text-white" />
+          </div>
+          <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
+          <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
+          <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
+            <span>{formatDate(link.created_at)}</span>
+            <span>{link.click_count} clicks</span>
+          </div>
+          <button
+            className="w-full mt-auto px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+            onClick={handleVisit}
+          >
+            Visit Link
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Layout for links not owned by the user
+  return (
+    <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col">
+      <div className="relative aspect-video">
+        {hasImage ? (
+          <img
+            src={link.preview!.image}
             alt={link.title}
             className="w-full h-full object-cover"
             onError={() => setImageError(true)}
           />
         ) : (
-          <DefaultPreview />
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500">
+            <LinkIcon size={48} className="text-white" />
+          </div>
         )}
         {link.preview?.favicon && !faviconError && (
           <img
             src={link.preview.favicon}
             alt="favicon"
-            className="link-card-favicon absolute top-2 left-2 w-6 h-6 rounded-full bg-white"
+            className="absolute top-2 left-2 w-6 h-6 rounded-full bg-white"
             onError={() => setFaviconError(true)}
           />
         )}
       </div>
-
-      <div className="p-6">
-        <h3 className="text-xl font-semibold mb-3 text-gray-900 dark:text-gray-100">
-          {link.title}
-        </h3>
-        <p className="mb-4 text-gray-600 dark:text-gray-400 line-clamp-2">
-          {link.description}
-        </p>
-        <div className="mt-4 flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+      <div className="p-4 flex-1 flex flex-col">
+        <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
+        <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
+        <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
           <span>{formatDate(link.created_at)}</span>
           <span>{link.click_count} clicks</span>
         </div>
+        <button
+          className="w-full mt-auto px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+          onClick={handleVisit}
+        >
+          Visit Link
+        </button>
       </div>
     </div>
   );

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { LinkIcon, ExternalLink, User as UserIcon, Calendar, Clock } from 'lucide-react';
 import { formatInTimeZone } from 'date-fns-tz';
+import ConfirmationModal from './ConfirmationModal';
 
 interface LinkPreview {
   title?: string;
@@ -35,14 +36,23 @@ interface LinkCardProps {
 const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   const [imageError, setImageError] = useState(false);
   const [faviconError, setFaviconError] = useState(false);
+  const [showModal, setShowModal] = useState(false);
 
   const isOwner = currentUser && link.user_id === currentUser.id;
   const hasImage = !!link.preview?.image && !imageError;
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
-    console.log(`Deleting link: ${link.id}`);
+    setShowModal(true);
+  };
+
+  const handleConfirmDelete = () => {
     if (onDelete) onDelete(link.id);
+    setShowModal(false);
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
   };
 
   const handleVisit = (e: React.MouseEvent) => {
@@ -122,6 +132,12 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
             >
               Delete
             </button>
+            <ConfirmationModal
+              isOpen={showModal}
+              onClose={handleCloseModal}
+              onConfirm={handleConfirmDelete}
+              message="Are you sure you want to delete this link?"
+            />
           </div>
         </div>
       </div>
@@ -168,6 +184,12 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           >
             Delete
           </button>
+          <ConfirmationModal
+            isOpen={showModal}
+            onClose={handleCloseModal}
+            onConfirm={handleConfirmDelete}
+            message="Are you sure you want to delete this link?"
+          />
         </div>
       </div>
     );

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -85,20 +85,19 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
           <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
             <span>{formatDate(link.created_at)}</span>
-            <span>{link.click_count} clicks</span>
           </div>
           <div className="mt-auto flex flex-col gap-2">
-            <button
-              className="ml-auto px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 transition"
-              onClick={handleDelete}
-            >
-              Delete
-            </button>
             <button
               className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
               onClick={handleVisit}
             >
               Visit Link
+            </button>
+            <button
+              className="w-full px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition text-sm"
+              onClick={handleDelete}
+            >
+              Delete
             </button>
           </div>
         </div>
@@ -109,13 +108,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   // Layout for owned links without images
   if (isOwner && !hasImage) {
     return (
-      <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col relative">
-        <button
-          className="absolute top-2 right-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition z-10"
-          onClick={handleDelete}
-        >
-          Delete
-        </button>
+      <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col">
         <div className="flex-1 flex flex-col p-4">
           <div className="w-full h-32 flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500 rounded mb-4">
             <LinkIcon size={48} className="text-white" />
@@ -124,13 +117,18 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
           <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
             <span>{formatDate(link.created_at)}</span>
-            <span>{link.click_count} clicks</span>
           </div>
           <button
-            className="w-full mt-auto px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+            className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
             onClick={handleVisit}
           >
             Visit Link
+          </button>
+          <button
+            className="w-full mt-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition text-sm"
+            onClick={handleDelete}
+          >
+            Delete
           </button>
         </div>
       </div>
@@ -167,10 +165,9 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
         <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
         <div className="flex items-center justify-between text-sm text-gray-400 mb-4">
           <span>{formatDate(link.created_at)}</span>
-          <span>{link.click_count} clicks</span>
         </div>
         <button
-          className="w-full mt-auto px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
+          className="w-full px-4 py-2 bg-purple-700 text-white rounded hover:bg-purple-800 transition"
           onClick={handleVisit}
         >
           Visit Link

--- a/my-link-uploader/src/components/SuccessModal.tsx
+++ b/my-link-uploader/src/components/SuccessModal.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { CheckCircle2 } from 'lucide-react';
+
+interface SuccessModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  message: string;
+}
+
+const SuccessModal: React.FC<SuccessModalProps> = ({ isOpen, onClose, message }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Overlay */}
+      <div
+        className="fixed inset-0 bg-black bg-opacity-60 transition-opacity"
+        onClick={onClose}
+      />
+      {/* Modal content */}
+      <div className="relative z-10 bg-gray-900 rounded-xl shadow-2xl p-8 w-full max-w-md mx-auto flex flex-col items-center border border-gray-700">
+        <div className="flex flex-col items-center mb-6">
+          <div className="w-16 h-16 flex items-center justify-center rounded-full bg-gradient-to-br from-purple-600 to-pink-500 mb-4">
+            <CheckCircle2 size={40} className="text-green-300" />
+          </div>
+          <p className="text-lg text-gray-100 font-semibold text-center">{message}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SuccessModal; 

--- a/my-link-uploader/src/pages/dashboard/DashboardPage.tsx
+++ b/my-link-uploader/src/pages/dashboard/DashboardPage.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
 import { useTheme } from "../../hooks/useTheme";
 import ApiService, { Link } from "../../services/api";
+import LinkCard from '../../components/LinkCard';
 
 export default function DashboardPage() {
   const [query, setQuery] = useState<string>("")
@@ -74,6 +75,17 @@ export default function DashboardPage() {
     } catch (error) {
       console.error('Error incrementing click count:', error);
       window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  const handleDeleteLink = async (id: string) => {
+    try {
+      await ApiService.deleteLink(id);
+      setLinks((prev) => prev.filter((l) => l.id !== id));
+      setFilteredLinks((prev) => prev.filter((l) => l.id !== id));
+    } catch (error) {
+      console.error('Failed to delete link:', error);
+      // Optionally show a toast or error message here
     }
   };
 
@@ -176,64 +188,11 @@ export default function DashboardPage() {
                     : "bg-gray-100/60 border-gray-200/60 hover:border-purple-400/20"
                 }`}
               >
-                {/* Link Preview Image */}
-                {link.preview?.image && (
-                  <div className="relative aspect-[16/9] w-full overflow-hidden">
-                    <img
-                      src={link.preview.image}
-                      alt={link.title}
-                      className="w-full h-full object-cover"
-                    />
-                    <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
-                  </div>
-                )}
-
-                <div className="p-6">
-                  {/* Link Title */}
-                  <h3 className={`text-xl font-semibold mb-3 ${
-                    isDark ? "text-gray-100" : "text-gray-600"
-                  }`}>
-                    {link.title}
-                  </h3>
-
-                  {/* Link Description */}
-                  <p className={`mb-4 line-clamp-2 ${
-                    isDark ? "text-gray-400" : "text-gray-500/90"
-                  }`}>
-                    {link.description}
-                  </p>
-
-                  {/* Link Metadata */}
-                  <div className={`flex flex-wrap gap-4 mb-4 text-sm ${
-                    isDark ? "text-gray-400" : "text-gray-500/80"
-                  }`}>
-                    <div className="flex items-center gap-1">
-                      <User size={16} />
-                      <span>{link.user?.username || 'Unknown user'}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Calendar size={16} />
-                      <span>{formatDate(link.created_at)}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Clock size={16} />
-                      <span>{formatTime(link.created_at)}</span>
-                    </div>
-                  </div>
-
-                  {/* Visit Link Button */}
-                  <button
-                    onClick={() => handleLinkClick(link.id, link.url)}
-                    className={`w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 ${
-                      isDark
-                        ? "bg-purple-500/10 text-purple-400 hover:bg-purple-500/20"
-                        : "bg-purple-50/40 text-purple-500/80 hover:bg-purple-100/40"
-                    }`}
-                  >
-                    <ExternalLink size={20} />
-                    <span>Visit Link</span>
-                  </button>
-                </div>
+                <LinkCard
+                  link={link}
+                  currentUser={auth?.user ? { id: auth.user.id, username: auth.user.username } : null}
+                  onDelete={handleDeleteLink}
+                />
               </motion.div>
             ))
           )}


### PR DESCRIPTION
This PR adds a "Delete" button to each link card, visible only to the link owner, allowing users to delete their own links as described in issue #38. The UI and logic ensure only the owner can see and use the button. All other card features and styles remain unchanged.

How to run/test:
1. Pull the branch and install dependencies if needed (npm install in my-link-uploader).
2. Start the frontend:
   `cd my-link-uploader
   npm run dev`
3. Log in as a user and navigate to the dashboard.
4. You should see a "Delete" button only on your own links. Clicking it will ask you an option to cancel or remove the link.
