### PR TITLE
Implement Secure Token Refresh and Session Management

### DIFF
--- a/backend/.sqlx/query-22a02075ad1c81bf24d1ab21523cebcf67e402dd870e48f63b4cbbf670b604f3.json
+++ b/backend/.sqlx/query-22a02075ad1c81bf24d1ab21523cebcf67e402dd870e48f63b4cbbf670b604f3.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO users (email, username, password_hash, is_verified)\n        VALUES ($1, $2, $3, false)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "22a02075ad1c81bf24d1ab21523cebcf67e402dd870e48f63b4cbbf670b604f3"
+}

--- a/backend/.sqlx/query-22f8cab19e8ce8be3a0c60a56241a2d4ed2ddafe6790309dc0a4eacf2569d710.json
+++ b/backend/.sqlx/query-22f8cab19e8ce8be3a0c60a56241a2d4ed2ddafe6790309dc0a4eacf2569d710.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as count\n            FROM users\n            WHERE email = $1 OR username = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "22f8cab19e8ce8be3a0c60a56241a2d4ed2ddafe6790309dc0a4eacf2569d710"
+}

--- a/backend/.sqlx/query-331e8379848ed523f02d7bacc2938f13a6d07758ebab75c6dc417c134005b730.json
+++ b/backend/.sqlx/query-331e8379848ed523f02d7bacc2938f13a6d07758ebab75c6dc417c134005b730.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE links \n        SET click_count = click_count + 1 \n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "331e8379848ed523f02d7bacc2938f13a6d07758ebab75c6dc417c134005b730"
+}

--- a/backend/.sqlx/query-51ba17f40573f8680a8fd2476a24fe87d98ec682d05e926383a9efbd43f326c9.json
+++ b/backend/.sqlx/query-51ba17f40573f8680a8fd2476a24fe87d98ec682d05e926383a9efbd43f326c9.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO refresh_tokens (user_id, token, expires_at)\n        VALUES ($1, $2, $3)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "51ba17f40573f8680a8fd2476a24fe87d98ec682d05e926383a9efbd43f326c9"
+}

--- a/backend/.sqlx/query-54c9424b27d9a817a1ab9496618bae162437bca4e6548c8dad720f7b21b683bc.json
+++ b/backend/.sqlx/query-54c9424b27d9a817a1ab9496618bae162437bca4e6548c8dad720f7b21b683bc.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as count\n            FROM users\n            WHERE email = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "54c9424b27d9a817a1ab9496618bae162437bca4e6548c8dad720f7b21b683bc"
+}

--- a/backend/.sqlx/query-5f6e61e66b52640ed3c28e05f0035160e5c97f4d5ffb51acc2315303891e0be6.json
+++ b/backend/.sqlx/query-5f6e61e66b52640ed3c28e05f0035160e5c97f4d5ffb51acc2315303891e0be6.json
@@ -1,0 +1,76 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT \n            l.id,\n            l.url as \"url!\",\n            l.title as \"title!\",\n            l.description as \"description!\",\n            l.user_id as \"user_id!\",\n            l.click_count as \"click_count!\",\n            l.created_at as \"created_at!\",\n            l.updated_at as \"updated_at!\",\n            l.preview as \"preview: JsonLinkPreview\",\n            COALESCE(\n                jsonb_build_object('username', u.username)::jsonb,\n                'null'::jsonb\n            ) as \"user!: OptionalJsonUser\"\n        FROM links l\n        LEFT JOIN users u ON l.user_id = u.id\n        WHERE l.id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "url!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "user_id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "click_count!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "preview: JsonLinkPreview",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "user!: OptionalJsonUser",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "5f6e61e66b52640ed3c28e05f0035160e5c97f4d5ffb51acc2315303891e0be6"
+}

--- a/backend/.sqlx/query-648a8b853f464c6c587b98caf12dd692b88c6d129282897ad896d7b7cd3b8106.json
+++ b/backend/.sqlx/query-648a8b853f464c6c587b98caf12dd692b88c6d129282897ad896d7b7cd3b8106.json
@@ -1,0 +1,105 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT \n            id, email, username, password_hash, \n            gender as \"gender: _\",\n            status as \"status: _\",\n            is_verified,\n            verification_attempts,\n            verified_at,\n            created_at, \n            updated_at\n        FROM users\n        WHERE email = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "gender: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female",
+                "other"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "status: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "inactive",
+                "suspended",
+                "pending_verification"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "is_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "verification_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "648a8b853f464c6c587b98caf12dd692b88c6d129282897ad896d7b7cd3b8106"
+}

--- a/backend/.sqlx/query-68a55a6382828ec882f65c497fb02dd884db83fe44beced3fe3ca5a6f0c96ca9.json
+++ b/backend/.sqlx/query-68a55a6382828ec882f65c497fb02dd884db83fe44beced3fe3ca5a6f0c96ca9.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT user_id, expires_at FROM refresh_tokens WHERE token = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "68a55a6382828ec882f65c497fb02dd884db83fe44beced3fe3ca5a6f0c96ca9"
+}

--- a/backend/.sqlx/query-6fb25d1ddaf16de0e87ba591bba53f6850cd8f382ed54c2884f32e907809823e.json
+++ b/backend/.sqlx/query-6fb25d1ddaf16de0e87ba591bba53f6850cd8f382ed54c2884f32e907809823e.json
@@ -1,0 +1,132 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO users (\n                email, username, password_hash, gender, \n                status, is_verified, verification_attempts\n            )\n            VALUES ($1, $2, $3, $4, $5, false, 0)\n            RETURNING \n                id, email, username, password_hash, \n                gender as \"gender: _\", \n                status as \"status: _\",\n                is_verified,\n                verification_attempts,\n                verified_at,\n                created_at, \n                updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "gender: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female",
+                "other"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "status: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "inactive",
+                "suspended",
+                "pending_verification"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "is_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "verification_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "user_gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female",
+                "other"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "user_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "inactive",
+                "suspended",
+                "pending_verification"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6fb25d1ddaf16de0e87ba591bba53f6850cd8f382ed54c2884f32e907809823e"
+}

--- a/backend/.sqlx/query-818622d4d4b01549109cc92e93f7df100ded5dac448e46e362a8220ec6661b9f.json
+++ b/backend/.sqlx/query-818622d4d4b01549109cc92e93f7df100ded5dac448e46e362a8220ec6661b9f.json
@@ -1,0 +1,105 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT \n                    id, email, username, password_hash, \n                    gender as \"gender: _\",\n                    status as \"status: _\",\n                    is_verified,\n                    verification_attempts,\n                    verified_at,\n                    created_at, \n                    updated_at\n                FROM users\n                WHERE id = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "gender: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female",
+                "other"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "status: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "inactive",
+                "suspended",
+                "pending_verification"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "is_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "verification_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "818622d4d4b01549109cc92e93f7df100ded5dac448e46e362a8220ec6661b9f"
+}

--- a/backend/.sqlx/query-a22112917fb062fa6fa0eebab231731711d3f632a0c5ee4ecc29c08c84999a5f.json
+++ b/backend/.sqlx/query-a22112917fb062fa6fa0eebab231731711d3f632a0c5ee4ecc29c08c84999a5f.json
@@ -1,0 +1,106 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT \n            id, email, username, password_hash, \n            gender as \"gender: _\",\n            status as \"status: _\",\n            is_verified,\n            verification_attempts,\n            verified_at,\n            created_at, \n            updated_at\n        FROM users\n        WHERE email = $1 OR username = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "gender: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female",
+                "other"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "status: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "inactive",
+                "suspended",
+                "pending_verification"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "is_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "verification_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "a22112917fb062fa6fa0eebab231731711d3f632a0c5ee4ecc29c08c84999a5f"
+}

--- a/backend/.sqlx/query-a44e82c2365f666b3887dd152c85805c532416336dafd3adddec9e944a188e4e.json
+++ b/backend/.sqlx/query-a44e82c2365f666b3887dd152c85805c532416336dafd3adddec9e944a188e4e.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM refresh_tokens WHERE expires_at < NOW()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "a44e82c2365f666b3887dd152c85805c532416336dafd3adddec9e944a188e4e"
+}

--- a/backend/.sqlx/query-a5c38712f43a1193eb810d8635819fbd044cb70eef6245928d6d0ebd342b5a0e.json
+++ b/backend/.sqlx/query-a5c38712f43a1193eb810d8635819fbd044cb70eef6245928d6d0ebd342b5a0e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE links \n                SET preview = $1 \n                WHERE id = $2\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a5c38712f43a1193eb810d8635819fbd044cb70eef6245928d6d0ebd342b5a0e"
+}

--- a/backend/.sqlx/query-b040aaaec10552a163f46d9d12d690681da71fe7e557b762b6d039e93d90f059.json
+++ b/backend/.sqlx/query-b040aaaec10552a163f46d9d12d690681da71fe7e557b762b6d039e93d90f059.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE users\n        SET \n            is_verified = true,\n            status = 'active',\n            verified_at = NOW()\n        WHERE email = $1 AND is_verified = false\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b040aaaec10552a163f46d9d12d690681da71fe7e557b762b6d039e93d90f059"
+}

--- a/backend/.sqlx/query-d5fcbbb502138662f670111479633938368ca7a29212cf4f72567efc4cd81a85.json
+++ b/backend/.sqlx/query-d5fcbbb502138662f670111479633938368ca7a29212cf4f72567efc4cd81a85.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM links WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d5fcbbb502138662f670111479633938368ca7a29212cf4f72567efc4cd81a85"
+}

--- a/backend/.sqlx/query-da3d249b027d35ebae5f42d5f216a4bba661d489b447f0732c48438ffbd42655.json
+++ b/backend/.sqlx/query-da3d249b027d35ebae5f42d5f216a4bba661d489b447f0732c48438ffbd42655.json
@@ -1,0 +1,81 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH inserted_link AS (\n            INSERT INTO links (url, title, description, user_id, created_at, updated_at, preview)\n            VALUES ($1, $2, $3, $4, $5, $5, $6)\n            RETURNING *\n        )\n        SELECT \n            l.id,\n            l.url as \"url!\",\n            l.title as \"title!\",\n            l.description as \"description!\",\n            l.user_id as \"user_id!\",\n            l.click_count as \"click_count!\",\n            l.created_at as \"created_at!\",\n            l.updated_at as \"updated_at!\",\n            l.preview as \"preview: JsonLinkPreview\",\n            COALESCE(\n                jsonb_build_object('username', u.username)::jsonb,\n                'null'::jsonb\n            ) as \"user!: OptionalJsonUser\"\n        FROM inserted_link l\n        LEFT JOIN users u ON l.user_id = u.id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "url!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "user_id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "click_count!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "preview: JsonLinkPreview",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "user!: OptionalJsonUser",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Text",
+        "Uuid",
+        "Timestamptz",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "da3d249b027d35ebae5f42d5f216a4bba661d489b447f0732c48438ffbd42655"
+}

--- a/backend/.sqlx/query-df5c57907d0f7035eb43c353ecfcffed2cce0167a4fdff446f7a4961d824b41f.json
+++ b/backend/.sqlx/query-df5c57907d0f7035eb43c353ecfcffed2cce0167a4fdff446f7a4961d824b41f.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT is_verified\n        FROM users\n        WHERE email = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_verified",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "df5c57907d0f7035eb43c353ecfcffed2cce0167a4fdff446f7a4961d824b41f"
+}

--- a/backend/.sqlx/query-e3aec0e000a2606a5732f3f3dfc1f29b3e9fe6c2234cbbdf89d3b537c4b0744c.json
+++ b/backend/.sqlx/query-e3aec0e000a2606a5732f3f3dfc1f29b3e9fe6c2234cbbdf89d3b537c4b0744c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM refresh_tokens WHERE token = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e3aec0e000a2606a5732f3f3dfc1f29b3e9fe6c2234cbbdf89d3b537c4b0744c"
+}

--- a/backend/.sqlx/query-f8fc3f2c9f137a53e20ec204b31afa31b85dbdd91fec9306e0f63da6ad49e19c.json
+++ b/backend/.sqlx/query-f8fc3f2c9f137a53e20ec204b31afa31b85dbdd91fec9306e0f63da6ad49e19c.json
@@ -1,0 +1,74 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT \n            l.id,\n            l.url as \"url!\",\n            l.title as \"title!\",\n            l.description as \"description!\",\n            l.user_id as \"user_id!\",\n            l.click_count as \"click_count!\",\n            l.created_at as \"created_at!\",\n            l.updated_at as \"updated_at!\",\n            l.preview as \"preview: JsonLinkPreview\",\n            COALESCE(\n                jsonb_build_object('username', u.username)::jsonb,\n                'null'::jsonb\n            ) as \"user!: OptionalJsonUser\"\n        FROM links l\n        LEFT JOIN users u ON l.user_id = u.id\n        ORDER BY l.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "url!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "title!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "user_id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 5,
+        "name": "click_count!",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "preview: JsonLinkPreview",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 9,
+        "name": "user!: OptionalJsonUser",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "f8fc3f2c9f137a53e20ec204b31afa31b85dbdd91fec9306e0f63da6ad49e19c"
+}

--- a/backend/.sqlx/query-fd9c2c5247366760ba028edd919d0420b68eb17b32d70ad15bd467fc89638d1f.json
+++ b/backend/.sqlx/query-fd9c2c5247366760ba028edd919d0420b68eb17b32d70ad15bd467fc89638d1f.json
@@ -1,0 +1,105 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT \n                id, email, username, password_hash, \n                gender as \"gender: _\",\n                status as \"status: _\",\n                is_verified,\n                verification_attempts,\n                verified_at,\n                created_at, \n                updated_at\n            FROM users\n            WHERE email = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "gender: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_gender",
+            "kind": {
+              "Enum": [
+                "male",
+                "female",
+                "other"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "status: _",
+        "type_info": {
+          "Custom": {
+            "name": "user_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "inactive",
+                "suspended",
+                "pending_verification"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "is_verified",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "verification_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "fd9c2c5247366760ba028edd919d0420b68eb17b32d70ad15bd467fc89638d1f"
+}

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-macros",
+ "base64",
  "bcrypt",
  "chrono",
  "derive_more 2.0.1",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,7 +11,7 @@ tower-http = { version = "0.6.6", features = ["cors", "trace"] }
 tokio = { version = "1.45.1", features = ["full", "macros", "rt-multi-thread"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json", "offline"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json"] }
 dotenv = "0.15.0"
 env_logger = "0.11.8"
 log = "0.4.27"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -11,7 +11,7 @@ tower-http = { version = "0.6.6", features = ["cors", "trace"] }
 tokio = { version = "1.45.1", features = ["full", "macros", "rt-multi-thread"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json"] }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json", "offline"] }
 dotenv = "0.15.0"
 env_logger = "0.11.8"
 log = "0.4.27"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -47,6 +47,7 @@ anyhow = "1.0.98"
 
 # Add resend client
 resend = "0.1.4"
+base64 = "0.22.1"
 
 [workspace]
 members = ["."]

--- a/backend/migrations/20240716103000_add_refresh_tokens_table.sql
+++ b/backend/migrations/20240716103000_add_refresh_tokens_table.sql
@@ -1,0 +1,14 @@
+-- Add refresh_tokens table for storing user refresh tokens
+CREATE TABLE refresh_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token VARCHAR(255) NOT NULL UNIQUE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+);
+
+-- Index for quick lookup by token
+CREATE INDEX idx_refresh_tokens_token ON refresh_tokens(token);
+
+-- Index for user_id (optional, for multi-device support)
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id); 

--- a/backend/src/database/queries.rs
+++ b/backend/src/database/queries.rs
@@ -304,15 +304,9 @@ pub async fn get_refresh_token(
 }
 
 /// Deletes a refresh token (for rotation or logout)
-pub async fn delete_refresh_token(
-    pool: &PgPool,
-    token: &str,
-) -> Result<(), sqlx::Error> {
-    sqlx::query!(
-        r#"DELETE FROM refresh_tokens WHERE token = $1"#,
-        token
-    )
-    .execute(pool)
-    .await?;
+pub async fn delete_refresh_token(pool: &PgPool, token: &str) -> Result<(), sqlx::Error> {
+    sqlx::query!(r#"DELETE FROM refresh_tokens WHERE token = $1"#, token)
+        .execute(pool)
+        .await?;
     Ok(())
 }

--- a/backend/src/database/queries.rs
+++ b/backend/src/database/queries.rs
@@ -1,8 +1,8 @@
 use super::models::{JsonLinkPreview, Link, LinkPreview};
+use crate::database::models::OptionalJsonUser;
 use chrono::Utc;
 use sqlx::PgPool;
 use uuid::Uuid;
-use crate::database::models::OptionalJsonUser;
 
 /// Retrieves all links from the database
 ///

--- a/backend/src/database/queries.rs
+++ b/backend/src/database/queries.rs
@@ -1,7 +1,8 @@
-use super::models::{JsonLinkPreview, Link, LinkPreview, OptionalJsonUser};
+use super::models::{JsonLinkPreview, Link, LinkPreview};
 use chrono::Utc;
 use sqlx::PgPool;
 use uuid::Uuid;
+use crate::database::models::OptionalJsonUser;
 
 /// Retrieves all links from the database
 ///

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -1,3 +1,4 @@
+use crate::models::auth::User;
 use crate::services::auth::AuthService;
 use crate::{
     api::{ApiResponse, ErrorResponse},
@@ -7,7 +8,6 @@ use crate::{
         VerifyEmailRequest,
     },
 };
-use crate::models::auth::User;
 use axum::extract::Json as AxumJson;
 use axum::{
     extract::State,

--- a/backend/src/handlers/auth.rs
+++ b/backend/src/handlers/auth.rs
@@ -3,10 +3,11 @@ use crate::{
     api::{ApiResponse, ErrorResponse},
     auth::routes::AppState,
     models::auth::{
-        AuthResponse, LoginRequest, RegisterRequest, ResendOtpRequest, User, UserStatus,
+        AuthResponse, LoginRequest, RegisterRequest, ResendOtpRequest, UserStatus,
         VerifyEmailRequest,
     },
 };
+use crate::models::auth::User;
 use axum::extract::Json as AxumJson;
 use axum::{
     extract::State,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -17,10 +17,10 @@ use axum::{
 use dotenv::dotenv;
 use std::env;
 use std::net::SocketAddr;
+use tokio::time::{sleep, Duration as TokioDuration};
 use tower_http::cors::CorsLayer;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
-use tokio::time::{sleep, Duration as TokioDuration};
 
 #[tokio::main]
 async fn main() {

--- a/backend/src/models/auth.rs
+++ b/backend/src/models/auth.rs
@@ -89,6 +89,7 @@ pub struct LoginRequest {
 pub struct AuthResponse {
     #[schema(example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")]
     pub token: String,
+    pub refresh_token: String,
     pub user: User,
 }
 

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -4,7 +4,7 @@ use axum::{
 };
 
 use crate::{
-    handlers::auth::{register, login, verify_email, resend_otp, refresh_token},
+    handlers::auth::{register, login, verify_email, resend_otp, refresh_token, logout},
     services::{auth::AuthService, email::EmailService},
 };
 
@@ -26,5 +26,6 @@ pub fn create_router(auth_service: AuthService, email_service: EmailService) -> 
         .route("/verify", post(verify_email))
         .route("/resend-otp", post(resend_otp))
         .route("/refresh", post(refresh_token))
+        .route("/logout", post(logout))
         .with_state(state)
 } 

--- a/backend/src/routes/auth.rs
+++ b/backend/src/routes/auth.rs
@@ -4,7 +4,7 @@ use axum::{
 };
 
 use crate::{
-    handlers::auth::{register, login, verify_email, resend_otp},
+    handlers::auth::{register, login, verify_email, resend_otp, refresh_token},
     services::{auth::AuthService, email::EmailService},
 };
 
@@ -25,5 +25,6 @@ pub fn create_router(auth_service: AuthService, email_service: EmailService) -> 
         .route("/login", post(login))
         .route("/verify", post(verify_email))
         .route("/resend-otp", post(resend_otp))
+        .route("/refresh", post(refresh_token))
         .with_state(state)
 } 

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -2,8 +2,9 @@ use bcrypt::{hash, verify, DEFAULT_COST};
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey, Header};
 use sqlx::PgPool;
+use rand::Rng;
 use rand::RngCore;
-use rand::rngs::OsRng;
+use rand::thread_rng;
 use base64::{engine::general_purpose, Engine as _};
 
 use crate::{
@@ -120,9 +121,9 @@ impl AuthService {
     }
 
     /// Generate a secure random refresh token and expiry (30 days)
-    fn generate_refresh_token_and_expiry() -> (String, chrono::DateTime<chrono::Utc>) {
+    pub fn generate_refresh_token_and_expiry() -> (String, chrono::DateTime<chrono::Utc>) {
         let mut bytes = [0u8; 32];
-        OsRng.fill_bytes(&mut bytes);
+        thread_rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
         let expires_at = Utc::now() + Duration::days(30);
         (token, expires_at)
@@ -132,7 +133,7 @@ impl AuthService {
         queries::complete_registration(&self.pool, email).await
     }
 
-    fn create_token(&self, user: &User) -> Result<String, sqlx::Error> {
+    pub fn create_token(&self, user: &User) -> Result<String, sqlx::Error> {
         let expiration = Utc::now()
             .checked_add_signed(Duration::hours(24))
             .expect("Valid timestamp")

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -125,7 +125,7 @@ impl AuthService {
         let mut bytes = [0u8; 32];
         thread_rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
-        let expires_at = Utc::now() + Duration::days(30); // 30 days expiry
+        let expires_at = Utc::now() + Duration::days(2); // 2 days expiry
         (token, expires_at)
     }
 

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -125,7 +125,7 @@ impl AuthService {
         let mut bytes = [0u8; 32];
         thread_rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
-        let expires_at = Utc::now() + Duration::seconds(30); // 30 seconds expiry for testing
+        let expires_at = Utc::now() + Duration::days(30); // 30 days expiry
         (token, expires_at)
     }
 

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -125,7 +125,7 @@ impl AuthService {
         let mut bytes = [0u8; 32];
         thread_rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
-        let expires_at = Utc::now() + Duration::days(30);
+        let expires_at = Utc::now() + Duration::seconds(30); // 30 seconds expiry for testing
         (token, expires_at)
     }
 

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -2,8 +2,7 @@ use base64::{engine::general_purpose, Engine as _};
 use bcrypt::{hash, verify, DEFAULT_COST};
 use chrono::{Duration, Utc};
 use jsonwebtoken::{encode, EncodingKey, Header};
-use rand::thread_rng;
-use rand::Rng;
+use rand::rng;
 use rand::RngCore;
 use sqlx::PgPool;
 
@@ -127,7 +126,7 @@ impl AuthService {
     /// Generate a secure random refresh token and expiry (30 days)
     pub fn generate_refresh_token_and_expiry() -> (String, chrono::DateTime<chrono::Utc>) {
         let mut bytes = [0u8; 32];
-        thread_rng().fill_bytes(&mut bytes);
+        rng().fill_bytes(&mut bytes);
         let token = general_purpose::URL_SAFE_NO_PAD.encode(&bytes);
         let expires_at = Utc::now() + Duration::days(2); // 2 days expiry
         (token, expires_at)

--- a/backend/src/services/auth.rs
+++ b/backend/src/services/auth.rs
@@ -145,7 +145,7 @@ impl AuthService {
 
     pub fn create_token(&self, user: &User) -> Result<String, sqlx::Error> {
         let expiration = Utc::now()
-            .checked_add_signed(Duration::seconds(30)) // 30 seconds expiry for testing
+            .checked_add_signed(Duration::hours(24)) // 24 hours expiry (default)
             .expect("Valid timestamp")
             .timestamp();
 

--- a/backend/src/services/email.rs
+++ b/backend/src/services/email.rs
@@ -291,7 +291,7 @@ impl EmailService {
                 .await
             {
                 Ok(_) => continue,
-                Err(e) => println!("Warning: Failed to delete key {url}: {e}"),
+                Err(e) => tracing::error!("Failed to delete key {url}: {e}"),
             }
         }
 

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -163,7 +163,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
       <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col">
         <div className="flex-1 flex flex-col p-4">
           <div className="w-full h-32 flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500 rounded mb-4">
-            <LinkIcon size={48} className="text-white" />
+      <LinkIcon size={48} className="text-white" />
           </div>
           <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
@@ -209,8 +209,8 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
             message="Link deleted successfully!"
           />
         </div>
-      </div>
-    );
+    </div>
+  );
   }
 
   // Layout for links not owned by the user
@@ -248,7 +248,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           </div>
           <div className="flex items-center gap-1">
             <Calendar size={16} />
-            <span>{formatDate(link.created_at)}</span>
+          <span>{formatDate(link.created_at)}</span>
           </div>
           <div className="flex items-center gap-1">
             <Clock size={16} />

--- a/my-link-uploader/src/contexts/AuthContext.tsx
+++ b/my-link-uploader/src/contexts/AuthContext.tsx
@@ -32,6 +32,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(response.data.user);
     setIsAuthenticated(true);
     localStorage.setItem('token', response.data.token);
+    localStorage.setItem('refresh_token', response.data.refresh_token);
     localStorage.setItem('user', JSON.stringify(response.data.user));
     navigate('/dashboard');
   };
@@ -40,6 +41,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setUser(null);
     setIsAuthenticated(false);
     localStorage.removeItem('token');
+    localStorage.removeItem('refresh_token');
     localStorage.removeItem('user');
     navigate('/login');
   };

--- a/my-link-uploader/src/pages/auth/LoginPage.tsx
+++ b/my-link-uploader/src/pages/auth/LoginPage.tsx
@@ -22,14 +22,15 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      const { token, user } = await ApiService.login(email, password);
+      const { token, refresh_token, user } = await ApiService.login(email, password);
       
-      if (!token || !user) {
+      if (!token || !refresh_token || !user) {
         throw new Error('Invalid credentials');
       }
 
-      // Set token and user in localStorage
+      // Set tokens and user in localStorage
       localStorage.setItem('token', token);
+      localStorage.setItem('refresh_token', refresh_token);
       localStorage.setItem('user', JSON.stringify(user));
       
       // Update context state
@@ -46,6 +47,7 @@ export default function LoginPage() {
       setUser(null);
       setIsAuthenticated(false);
       localStorage.removeItem('token');
+      localStorage.removeItem('refresh_token');
       localStorage.removeItem('user');
     } finally {
       setIsLoading(false);

--- a/my-link-uploader/src/pages/dashboard/DashboardPage.tsx
+++ b/my-link-uploader/src/pages/dashboard/DashboardPage.tsx
@@ -2,7 +2,7 @@
 
 import { formatInTimeZone } from 'date-fns-tz';
 import { motion } from "framer-motion";
-import { Calendar, Clock, ExternalLink, Search, User } from "lucide-react";
+import { Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../hooks/useAuth";
@@ -68,16 +68,6 @@ export default function DashboardPage() {
     setQuery(searchQuery);
   };
 
-  const handleLinkClick = async (id: string, url: string) => {
-    try {
-      await ApiService.incrementLinkClick(id);
-      window.open(url, '_blank', 'noopener,noreferrer');
-    } catch (error) {
-      console.error('Error incrementing click count:', error);
-      window.open(url, '_blank', 'noopener,noreferrer');
-    }
-  };
-
   const handleDeleteLink = async (id: string) => {
     try {
       await ApiService.deleteLink(id);
@@ -86,30 +76,6 @@ export default function DashboardPage() {
     } catch (error) {
       console.error('Failed to delete link:', error);
       // Optionally show a toast or error message here
-    }
-  };
-
-  const formatDate = (dateString: string | null | undefined): string => {
-    if (!dateString) return 'N/A';
-    try {
-      // Parse the date string directly, it's already in UTC format from the backend
-      const date = new Date(dateString);
-      return formatInTimeZone(date, 'Africa/Douala', 'MMM d, yyyy');
-    } catch (error) {
-      console.error('Error formatting date:', error);
-      return 'Invalid date';
-    }
-  };
-
-  const formatTime = (dateString: string | null | undefined): string => {
-    if (!dateString) return 'N/A';
-    try {
-      // Parse the date string directly, it's already in UTC format from the backend
-      const date = new Date(dateString);
-      return formatInTimeZone(date, 'Africa/Douala', 'HH:mm');
-    } catch (error) {
-      console.error('Error formatting time:', error);
-      return 'Invalid time';
     }
   };
 

--- a/my-link-uploader/src/pages/dashboard/DashboardPage.tsx
+++ b/my-link-uploader/src/pages/dashboard/DashboardPage.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { formatInTimeZone } from 'date-fns-tz';
 import { motion } from "framer-motion";
 import { Search } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/my-link-uploader/src/pages/dashboard/MyAccountPage.tsx
+++ b/my-link-uploader/src/pages/dashboard/MyAccountPage.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { useAuth } from '../../hooks/useAuth';
 import { useTheme } from '../../hooks/useTheme';
-import { User } from 'lucide-react';
 
 export default function MyAccountPage() {
   const { user } = useAuth();

--- a/my-link-uploader/src/services/api.ts
+++ b/my-link-uploader/src/services/api.ts
@@ -121,9 +121,9 @@ export const ApiService = {
     }
   },
 
-  async login(email: string, password: string): Promise<{ token: string; user: User }> {
+  async login(email: string, password: string): Promise<{ token: string; refresh_token: string; user: User }> {
     try {
-      const response = await api.post<ApiResponse<{ token: string; user: User }>>('/auth/login', {
+      const response = await api.post<ApiResponse<{ token: string; refresh_token: string; user: User }>>('/auth/login', {
         email,
         password
       });

--- a/my-link-uploader/src/services/api.ts
+++ b/my-link-uploader/src/services/api.ts
@@ -84,9 +84,9 @@ async function refreshToken(): Promise<{ token: string; refresh_token: string; u
 
 // Update axios interceptor for 401
 let isRefreshing = false;
-let failedQueue: any[] = [];
+let failedQueue: unknown[] = [];
 
-function processQueue(error: any, token: string | null = null) {
+function processQueue(error: unknown, token: string | null = null) {
   failedQueue.forEach(prom => {
     if (error) {
       prom.reject(error);

--- a/my-link-uploader/src/services/api.ts
+++ b/my-link-uploader/src/services/api.ts
@@ -197,7 +197,16 @@ export const ApiService = {
   },
 
   async logout(): Promise<void> {
+    const refresh_token = localStorage.getItem('refresh_token');
+    if (refresh_token) {
+      try {
+        await api.post('/auth/logout', { refresh_token });
+      } catch (e) {
+        // Ignore errors, proceed to clear local storage
+      }
+    }
     localStorage.removeItem("token");
+    localStorage.removeItem("refresh_token");
     localStorage.removeItem("user");
   },
 


### PR DESCRIPTION
Description:
Closes #62
This PR implements a robust token refresh system for the LinkSphere backend, ensuring users can stay logged in securely without frequent re-authentication, and supporting secure session management.
What was done:
Added a refresh_tokens table and logic to store and rotate refresh tokens after login.
Implemented a /refresh endpoint to validate, rotate, and issue new access/refresh tokens.
Set refresh token expiration to 2 days for enhanced security.
Added a background task to clean up expired refresh tokens from the database every 3 days.
Cleaned up unnecessary debug logs and improved error handling throughout the authentication flow.
Ensured frontend and backend integration for seamless user experience and automatic token refresh.
(Optional) Added support for device/session metadata for future session management features.
Acceptance Criteria:
Users stay logged in without manual re-authentication.
Tokens are securely rotated and expired tokens are cleaned up regularly.
All requirements from issue #62 are met.
How to test:
Log in and confirm both access and refresh tokens are issued and stored.
Wait for the access token to expire, then confirm the refresh endpoint issues new tokens and keeps the user logged in.
Confirm expired refresh tokens are deleted from the database after 2 days (or by manually expiring them and running the cleanup).
Review logs to ensure only relevant error/info logs remain.