### PR TITLE
Fix LinkCard Size Inconsistencies and Remove Extra Space (#69)

### DIFF
--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -106,7 +106,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
             />
           )}
         </div>
-        <div className="p-4 flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col p-4">
           <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
           <div className="flex items-center gap-4 mb-2 text-sm text-gray-400">
@@ -161,10 +161,10 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
   if (isOwner && !hasImage) {
     return (
       <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col">
+        <div className="relative aspect-video flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500">
+          <LinkIcon size={48} className="text-white" />
+        </div>
         <div className="flex-1 flex flex-col p-4">
-          <div className="w-full h-32 flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500 rounded mb-4">
-      <LinkIcon size={48} className="text-white" />
-          </div>
           <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
           <div className="flex items-center gap-4 mb-2 text-sm text-gray-400">
@@ -184,33 +184,35 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           <div className="mb-4 text-sm text-gray-400">
             {link.click_count} clicks
           </div>
-          <button
-            className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
-            onClick={handleVisit}
-          >
-            <ExternalLink size={20} />
-            <span>Visit Link</span>
-          </button>
-          <button
-            className="w-full mt-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition text-sm"
-            onClick={handleDelete}
-          >
-            Delete
-          </button>
-          <ConfirmationModal
-            isOpen={showModal}
-            onClose={handleCloseModal}
-            onConfirm={handleConfirmDelete}
-            message="Are you sure you want to delete this link?"
-          />
-          <SuccessModal
-            isOpen={showSuccess}
-            onClose={handleCloseSuccess}
-            message="Link deleted successfully!"
-          />
+          <div className="mt-auto flex flex-col gap-2">
+            <button
+              className="w-full flex items-center justify-center space-x-2 px-4 py-3 rounded-lg transition-all duration-300 bg-[#231942] text-purple-400 hover:bg-[#2d2350]"
+              onClick={handleVisit}
+            >
+              <ExternalLink size={20} />
+              <span>Visit Link</span>
+            </button>
+            <button
+              className="w-full px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 transition text-sm"
+              onClick={handleDelete}
+            >
+              Delete
+            </button>
+            <ConfirmationModal
+              isOpen={showModal}
+              onClose={handleCloseModal}
+              onConfirm={handleConfirmDelete}
+              message="Are you sure you want to delete this link?"
+            />
+            <SuccessModal
+              isOpen={showSuccess}
+              onClose={handleCloseSuccess}
+              message="Link deleted successfully!"
+            />
+          </div>
         </div>
-    </div>
-  );
+      </div>
+    );
   }
 
   // Layout for links not owned by the user
@@ -238,7 +240,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           />
         )}
       </div>
-      <div className="p-4 flex-1 flex flex-col">
+      <div className="flex-1 flex flex-col p-4">
         <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
         <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
         <div className="flex items-center gap-4 mb-2 text-sm text-gray-400">
@@ -248,7 +250,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           </div>
           <div className="flex items-center gap-1">
             <Calendar size={16} />
-          <span>{formatDate(link.created_at)}</span>
+            <span>{formatDate(link.created_at)}</span>
           </div>
           <div className="flex items-center gap-1">
             <Clock size={16} />

--- a/my-link-uploader/src/components/LinkCard.tsx
+++ b/my-link-uploader/src/components/LinkCard.tsx
@@ -163,7 +163,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
       <div className="bg-gray-800 rounded-lg shadow-lg overflow-hidden flex flex-col">
         <div className="flex-1 flex flex-col p-4">
           <div className="w-full h-32 flex items-center justify-center bg-gradient-to-br from-purple-600 to-pink-500 rounded mb-4">
-            <LinkIcon size={48} className="text-white" />
+      <LinkIcon size={48} className="text-white" />
           </div>
           <h3 className="text-xl font-semibold mb-1 text-gray-100">{link.title}</h3>
           <p className="mb-2 text-gray-400 line-clamp-2">{link.description}</p>
@@ -209,8 +209,8 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
             message="Link deleted successfully!"
           />
         </div>
-      </div>
-    );
+    </div>
+  );
   }
 
   // Layout for links not owned by the user
@@ -248,7 +248,7 @@ const LinkCard: React.FC<LinkCardProps> = ({ link, currentUser, onDelete }) => {
           </div>
           <div className="flex items-center gap-1">
             <Calendar size={16} />
-            <span>{formatDate(link.created_at)}</span>
+          <span>{formatDate(link.created_at)}</span>
           </div>
           <div className="flex items-center gap-1">
             <Clock size={16} />


### PR DESCRIPTION
This pull request addresses Issue #69 by ensuring all LinkCards have a uniform appearance and size across the application:
Unified Card Height:
All LinkCards now have the same height, regardless of whether they display an image or an icon.
Consistent Top Area:
The icon area for cards without images now uses the same aspect ratio and layout as the image area, ensuring visual consistency.
No Extra Space:
Removed unnecessary space and color differences at the bottom of cards, so the "Delete" button is always aligned at the bottom with no gaps.
Improved Layout:
The card content and actions are consistently aligned, providing a cleaner and more professional interface.
These changes ensure a uniform and visually appealing grid of LinkCards throughout the dashboard and other interfaces.
